### PR TITLE
Missing coma

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ module.exports = function (grunt) {
   grunt.initConfig({
     tape: {
       options: {
-        pretty: true
+        pretty: true,
         output: 'console'
       },
       files: ['test/**/*.js']


### PR DESCRIPTION
Fixed a missing coma in the given readme example that will break it the grunt file.

