### PR TITLE
Use cross-spawn-async to spawn the tape process so it works on Windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,9 @@
     "grunt": "~0.4.0rc2"
   },
   "dependencies": {
-    "tape": "~2.3.2",
+    "cross-spawn-async": "^2.2.2",
     "faucet": "0.0.0",
+    "tape": "~2.3.2",
     "through": "~2.3.4"
   }
 }

--- a/tasks/tape.js
+++ b/tasks/tape.js
@@ -10,7 +10,7 @@
 
 var path = require('path'),
     fs = require('fs'),
-    spawn = require('child_process').spawn,
+    spawn = require('cross-spawn-async').spawn,
     faucet = require('faucet'),
     through = require('through');
 


### PR DESCRIPTION
See https://www.npmjs.com/package/cross-spawn-async and https://github.com/nodejs/node-v0.x-archive/issues/2318 for more details.
