### PR TITLE
Replace deprecated cross-spawn-async module with cross-spawn

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "grunt": "~0.4.0rc2"
   },
   "dependencies": {
-    "cross-spawn-async": "^2.2.2",
+    "cross-spawn": "^4.0.0",
     "faucet": "0.0.1",
     "tape": "^4.6.0",
     "through": "~2.3.4"

--- a/tasks/tape.js
+++ b/tasks/tape.js
@@ -10,7 +10,7 @@
 
 var path = require('path'),
     fs = require('fs'),
-    spawn = require('cross-spawn-async').spawn,
+    spawn = require('cross-spawn'),
     faucet = require('faucet'),
     through = require('through');
 


### PR DESCRIPTION
cross-spawn-async is deprecated.

This avoids the following warning on `npm install`

```
npm WARN deprecated cross-spawn-async@2.2.2: cross-spawn no longer requires a build toolchain, use it instead!
```

See https://github.com/IndigoUnited/node-cross-spawn-async
